### PR TITLE
Can I disable embedding images from urls 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ const editor = EditorJS({
         class: InlineImage,
         inlineToolbar: true,
         config: {
+          embed: {
+            display: true,
+          },
           unsplash: {
             appName: 'your_app_name',
             clientId: 'your_client_id'
@@ -55,6 +58,7 @@ const editor = EditorJS({
 
 | Field          | Type      | Description                     |
 | -------------- | --------- | ------------------------------- |
+| embed          | {display: boolean} | You could display or not the embed tab, If you don't fill the embed config by default the value is set on true
 | unsplash       | `{appName: string, clientId: string, maxResults: string}`  | Config for **Unsplash API**. Contains 3 fields: <br><br> **appName**: Unspalsh `Application Name`. <br><br> **clientId**: Unsplash `Access Key`. <br><br> **maxResults**: Max number of images per search (default 30).                    |
 
 ## Tool's tunes

--- a/src/controlPanel.js
+++ b/src/controlPanel.js
@@ -52,6 +52,7 @@ export default class ControlPanel {
 
     this.unsplashClient = new UnsplashClient(this.config.unsplash);
     this.searchTimeout = null;
+    this.showEmbedTab = this.config.embed ? this.config.embed.display : true
   }
 
   /**
@@ -66,7 +67,7 @@ export default class ControlPanel {
       innerHTML: 'Embed URL',
       onclick: () => this.showEmbedUrlPanel(),
     });
-    const unsplashTab = make('div', this.cssClasses.tab, {
+    const unsplashTab = make('div', [this.cssClasses.tab, this.showEmbedTab ? null : this.cssClasses.active], {
       innerHTML: 'Unsplash',
       onclick: () => this.showUnsplashPanel(),
     });
@@ -74,16 +75,16 @@ export default class ControlPanel {
     const embedUrlPanel = this.renderEmbedUrlPanel();
     const unsplashPanel = this.renderUnsplashPanel();
 
-    tabWrapper.appendChild(embedUrlTab);
+    this.showEmbedTab && tabWrapper.appendChild(embedUrlTab);
     tabWrapper.appendChild(unsplashTab);
     wrapper.appendChild(tabWrapper);
-    wrapper.appendChild(embedUrlPanel);
+    this.showEmbedTab && wrapper.appendChild(embedUrlPanel);
     wrapper.appendChild(unsplashPanel);
 
-    this.nodes.embedUrlPanel = embedUrlPanel;
+    this.nodes.embedUrlPanel = this.showEmbedTab ? embedUrlPanel : null;
     this.nodes.unsplashPanel = unsplashPanel;
-    this.nodes.embedUrlTab = embedUrlTab;
-    this.nodes.unsplashTab = unsplashTab;
+    this.nodes.embedUrlTab   = this.showEmbedTab ? embedUrlTab : null;
+    this.nodes.unsplashTab   = unsplashTab;
 
     return wrapper;
   }
@@ -160,7 +161,7 @@ export default class ControlPanel {
    * @returns {HTMLDivElement}
    */
   renderUnsplashPanel() {
-    const wrapper = make('div', this.cssClasses.hidden);
+    const wrapper = make('div', this.showEmbedTab ? this.cssClasses.hidden : null);
     const imageGallery = make('div', this.cssClasses.imageGallery);
     const searchInput = make('div', [this.cssClasses.input, this.cssClasses.caption, this.cssClasses.search], {
       id: 'unsplash-search',

--- a/test/controlPanel.test.js
+++ b/test/controlPanel.test.js
@@ -1,4 +1,5 @@
 import createControlPanel from './fixtures/controlPanel';
+import createControlPanelWithOutEmbed from './fixtures/ControlPanelWithOutEmbed';
 import { parsedResponse } from './fixtures/unsplashApi';
 import { triggerEvent } from './testHelpers';
 import UnsplashClient from '../src/unsplashClient';
@@ -135,4 +136,43 @@ describe('ControlPanel', () => {
       });
     });
   });
+});
+
+describe('ControlPanel without Embed', () => {
+  let controlPanel;
+
+  beforeEach(() => {
+    controlPanel = createControlPanelWithOutEmbed(onSelectImage, notify);
+    controlPanel.render();
+  });
+
+  describe('embed panel', () => {
+    let embedUrlPanel;
+    let embedUrlTab;
+
+    beforeEach(() => {
+      embedUrlPanel = controlPanel.nodes.embedUrlPanel;
+      embedUrlTab = controlPanel.nodes.embedUrlTab
+    });
+
+    it('the embed panel does not visible', () => {
+      expect(embedUrlPanel).toBeNull();
+      expect(embedUrlTab).toBeNull();
+    });
+
+  });
+
+  describe('unsplash is visible', () => {
+    let unsplashPanel;
+
+    beforeEach(() => {
+      unsplashPanel = controlPanel.nodes.unsplashPanel;
+    });
+
+    it('the unsplash panel has to be visible', () => {
+      expect(unsplashPanel).not.toBeEmptyDOMElement();
+      expect(unsplashPanel).not.toHaveClass('hidden');
+    });
+  });
+
 });

--- a/test/fixtures/controlPanelWithOutEmbed.js
+++ b/test/fixtures/controlPanelWithOutEmbed.js
@@ -1,0 +1,32 @@
+import ControlPanel from '../../src/controlPanel';
+import createApi from './editor';
+
+const cssClasses = {
+  caption: 'inline-image__input',
+};
+
+/**
+ * Config object without embed
+ */
+const config = {
+  embed:{
+    display: false,
+  },
+
+  unsplash: {
+    appName: 'test',
+  },
+};
+
+
+/**
+ * Creates an instance of ControlPanel
+ */
+const createControlPanelWithOutEmbed = (onSelectImage, notify) => new ControlPanel({
+  api: createApi(notify),
+  config,
+  cssClasses,
+  onSelectImage,
+});
+
+export default createControlPanelWithOutEmbed;


### PR DESCRIPTION
Main issue:
Can I disable embedding images from URLs?

Changes:
- Add new logic to accept embed display config.
![Screen Shot 2021-05-31 at 1 00 17 PM](https://user-images.githubusercontent.com/45491405/120228143-2753ca00-c210-11eb-86f6-60d7d93ec5e4.png)

- Update the readme with the new config.
- Add new tests to this use case:
<img width="291" alt="Screen Shot 2021-05-31 at 12 59 30 PM" src="https://user-images.githubusercontent.com/45491405/120228081-0c815580-c210-11eb-9c14-c41b714cd719.png">
