### PR TITLE
 ¿Could I connect a tool to publish to npm automatically?

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,19 @@
+name: Publish package to NPM
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - run: yarn install
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
Hi

You need to add a new environment variable, with the access token of the NPM account => NPM_TOKEN:
![Screen Shot 2021-07-05 at 9 07 44 PM](https://user-images.githubusercontent.com/45491405/124532006-475d4700-ddd5-11eb-9dfa-5f45b812328d.png)

Every time you make a new release, it will be automatically published to NPM.

Best.
