### PR TITLE
Fix common name collisions in css classes

### DIFF
--- a/src/controlPanel.js
+++ b/src/controlPanel.js
@@ -34,8 +34,8 @@ export default class ControlPanel {
       imgWrapper: 'inline-image__img-wrapper',
       thumb: 'inline-image__thumb',
       active: 'active',
-      hidden: 'hidden',
-      scroll: 'scroll',
+      hidden: 'panel-hidden',
+      scroll: 'panel-scroll',
     };
 
     this.onSelectImage = onSelectImage;

--- a/src/index.css
+++ b/src/index.css
@@ -144,10 +144,10 @@
   margin: 20px;
 }
 
-.hidden {
+.panel-hidden {
   display: none;
 }
 
-.scroll {
+.panel-scroll {
   overflow-y: scroll;
 }

--- a/test/controlPanel.test.js
+++ b/test/controlPanel.test.js
@@ -64,10 +64,10 @@ describe('ControlPanel', () => {
       unsplashPanel = controlPanel.nodes.unsplashPanel;
     });
 
-    it('creates the unsplash panel (hidden)', () => {
+    it('creates the unsplash panel (panel-hidden)', () => {
       expect(unsplashPanel).not.toBeEmptyDOMElement();
 
-      expect(unsplashPanel).toHaveClass('hidden');
+      expect(unsplashPanel).toHaveClass('panel-hidden');
     });
 
     describe('unsplash search', () => {
@@ -174,7 +174,7 @@ describe('ControlPanel without Embed', () => {
 
     it('the unsplash panel has to be visible', () => {
       expect(unsplashPanel).not.toBeEmptyDOMElement();
-      expect(unsplashPanel).not.toHaveClass('hidden');
+      expect(unsplashPanel).not.toHaveClass('panel-hidden');
     });
   });
 


### PR DESCRIPTION
Finishes #45. These classes interfere with tailwind, and probably other frameworks.

- Update class names to "panel-hidden" and "panel-scroll"
- Update the css file
- Update references in test file