### PR TITLE
Keep read-only permissions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,6 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 
 jobs:
   build:
-    permissions:
-      checks: write  # for coverallsapp/github-action to create new checks
-      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
     steps:
     - name: Harden Runner


### PR DESCRIPTION
Keep read-only permissions in CI workflow

https://api.securityscorecards.dev/projects/github.com/kommitters/editorjs-inline-image

![image](https://user-images.githubusercontent.com/39246879/209834285-faac1cf0-1d01-489f-85f5-13f4517b61f9.png)
