### PR TITLE
Release v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.1.1 (25.04.2024)
+* Add stale issues policy. See [PR #140](https://github.com/kommitters/editorjs-inline-image/pull/140)
+
 ## 2.1.0 (04.04.2024)
 
 * Update the security policy. See[PR #137](https://github.com/kommitters/editorjs-inline-image/pull/137)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,15 @@ At this point, you're waiting on us. We like to at least comment on pull request
 business days (typically, one business day). We may suggest some changes, improvements or
 alternatives.
 
+# Stale issues
+
+To ensure that our issue tracker remains organized and relevant, we have implemented a policy for handling Stale issues. Please review the following guidelines:
+
+1. **Marking as Stale**: Issues will be automatically marked as **Stale** after 60 days of inactivity.
+2. **Closing Stale Issues**: After an issue has been marked as Stale, a comment will be posted on the issue indicating that it will be closed if there is no further activity or information provided within a specified period.
+
+Thank you for helping us maintain a clean and efficient issue tracker!
+
 ## Additional resources
 
 * [EditorJS](https://editorjs.io/)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "editorjs-inline-image",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "keywords": [
     "tool",
     "image",


### PR DESCRIPTION
## 2.1.1 (25.04.2024)
* Add stale issues policy. See [PR #140](https://github.com/kommitters/editorjs-inline-image/pull/140)